### PR TITLE
feat(npm-publish-workflow): add version checks and conditional publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,20 +11,38 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'
+    - name: Compare package.json version with tag
+      run: |
+        TAG_VERSION=${GITHUB_REF#refs/tags/}
+        PACKAGE_VERSION=$(cat package.json | jq -r '.version')
+        # Expects the tag to be in the format v1.0.0
+        if [ "$TAG_VERSION" != "v$PACKAGE_VERSION" ]; then
+          echo "Tag version $TAG_VERSION does not match the package.json version $PACKAGE_VERSION"
+          exit 1
+        fi
+    - name: Check if version is a prerelease
+      id: prerelease_check
+      run: |
+        # Explicitly tests for a non-prerelease version, assuming that we're using semver
+        NON_PRERELEASE_VERSION=$(echo $PACKAGE_VERSION | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')
+        if [ ! -z "$NON_PRERELEASE_VERSION" ]; then
+          echo "is_next=false" >> $GITHUB_ENV
+        else
+          echo "is_next=true" >> $GITHUB_ENV
+        fi
     - name: Install dependencies
       run: yarn install --frozen-lockfile
-#    - name: Publish package release
-#      if: "!github.event.release.prerelease"
-#      run: yarn publish
-#      env:
-#        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - name: Publish package pre-release
-      if: "github.event.release.prerelease"
-      run: yarn publish --tag next
+    - name: Publish package
+      run: |
+        if [ "$is_next" = "true" ]; then
+          yarn publish --tag next
+        else
+          yarn publish
+        fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,7 @@ jobs:
       run: |
         TAG_VERSION=${GITHUB_REF#refs/tags/}
         PACKAGE_VERSION=$(cat package.json | jq -r '.version')
+        echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
         # Expects the tag to be in the format v1.0.0
         if [ "$TAG_VERSION" != "v$PACKAGE_VERSION" ]; then
           echo "Tag version $TAG_VERSION does not match the package.json version $PACKAGE_VERSION"


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit ccd6931efc12e635c223de997f6a29bbd83ea2a3.  | 
|--------|--------|

### Summary:
This PR enhances the npm publishing workflow by adding version checks and conditional publishing based on the version type.

**Key points**:
- Upgraded `actions/checkout` and `actions/setup-node` in `/.github/workflows/npm-publish.yml`
- Added steps to compare `package.json` version with tag and check for prerelease
- Updated publishing step to conditionally publish as prerelease or regular release


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)
<!--
ELLIPSIS_HIDDEN
-->
