### PR TITLE
feat(npm-publish workflow): add debug output step

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,22 +25,20 @@ jobs:
         if [ "$TAG_VERSION" != "v$PACKAGE_VERSION" ]; then
           echo "Tag version $TAG_VERSION does not match the package.json version $PACKAGE_VERSION"
           exit 1
-        fi
-    - name: Debug output
-      run: |
-        echo "PACKAGE_VERSION=${PACKAGE_VERSION}"
-        echo "NON_PRERELEASE_VERSION=${NON_PRERELEASE_VERSION}"
-        echo "is_next=${is_next}"
+        fi      
     - name: Check if version is a prerelease
       id: prerelease_check
       run: |
+        echo "PACKAGE_VERSION=${PACKAGE_VERSION}"
         # Explicitly tests for a non-prerelease version, assuming that we're using semver
         NON_PRERELEASE_VERSION=$(echo $PACKAGE_VERSION | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')
+        echo "NON_PRERELEASE_VERSION=${NON_PRERELEASE_VERSION}"
         if [ ! -z "$NON_PRERELEASE_VERSION" ]; then
           echo "is_next=false" >> $GITHUB_ENV
         else
           echo "is_next=true" >> $GITHUB_ENV
         fi
+        echo "is_next=${is_next}"
     - name: Install dependencies
       run: yarn install --frozen-lockfile
     - name: Publish package

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,6 +26,11 @@ jobs:
           echo "Tag version $TAG_VERSION does not match the package.json version $PACKAGE_VERSION"
           exit 1
         fi
+    - name: Debug output
+      run: |
+        echo "PACKAGE_VERSION=${PACKAGE_VERSION}"
+        echo "NON_PRERELEASE_VERSION=${NON_PRERELEASE_VERSION}"
+        echo "is_next=${is_next}"
     - name: Check if version is a prerelease
       id: prerelease_check
       run: |


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0c3fb31c25f9ece1d1b12724df4d5d3659989c89.  | 
|--------|--------|

### Summary:
This PR integrates a debug output step into the 'Check if version is a prerelease' step of the npm-publish GitHub Actions workflow to print the values of PACKAGE_VERSION, NON_PRERELEASE_VERSION, and is_next variables.

**Key points**:
- Added a debug output step in the npm-publish GitHub Actions workflow
- The debug output prints the values of PACKAGE_VERSION, NON_PRERELEASE_VERSION, and is_next variables
- The debug output was added to the 'Check if version is a prerelease' step


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)
<!--
ELLIPSIS_HIDDEN
-->
