### PR TITLE
refactor(npm-publish): simplify prerelease check and use grep for version checking

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,13 +27,9 @@ jobs:
           exit 1
         fi      
     - name: Check if version is a prerelease
-      id: prerelease_check
       run: |
-        echo "PACKAGE_VERSION=${PACKAGE_VERSION}"
-        # Explicitly tests for a non-prerelease version, assuming that we're using semver
-        NON_PRERELEASE_VERSION=$(echo $PACKAGE_VERSION | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$')
-        echo "NON_PRERELEASE_VERSION=${NON_PRERELEASE_VERSION}"
-        if [ ! -z "$NON_PRERELEASE_VERSION" ]; then
+        # grep will return a non-zero exit code if the version does not match the release pattern
+        if echo "$PACKAGE_VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' > /dev/null; then
           echo "is_next=false" >> $GITHUB_ENV
         else
           echo "is_next=true" >> $GITHUB_ENV


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit a1182ee5d2f49e5bc046154c59ffcc98b5cc47c9.  | 
|--------|--------|

### Summary:
This PR refactors the 'Check if version is a prerelease' step in `.github/workflows/npm-publish.yml` to be more concise and easier to understand by using grep to check the package version.

**Key points**:
- Simplified the 'Check if version is a prerelease' step in `.github/workflows/npm-publish.yml`.
- Removed unnecessary echo statements and explicit check for a non-prerelease version.
- Used grep to check if the package version matches the release pattern.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
