### PR TITLE
chore(.github/workflows/npm-publish.yml): clean debug code and improve prerelease output

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         if [ "$is_next" = "true" ]; then
           yarn publish --tag next
-        else
+yarn publish
           echo "should not have got here"
           # yarn publish
         fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,9 +41,8 @@ jobs:
       run: |
         if [ "$is_next" = "true" ]; then
           yarn publish --tag next
-yarn publish
-          echo "should not have got here"
-          # yarn publish
+        else
+          yarn publish
         fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,17 +30,15 @@ jobs:
       run: |
         # grep will return a non-zero exit code if the version does not match the release pattern
         if echo "$PACKAGE_VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' > /dev/null; then
-        echo "incorrect"
           echo "is_next=false" >> $GITHUB_ENV
         else
-          echo "correct"
+          echo "Packaging a prerelease version $PACKAGE_VERSION"
           echo "is_next=true" >> $GITHUB_ENV
         fi
     - name: Install dependencies
       run: yarn install --frozen-lockfile
     - name: Publish package
       run: |
-        echo "is_next=${is_next}"
         if [ "$is_next" = "true" ]; then
           yarn publish --tag next
         else


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 19c763a222b01b238dc3cc782169c6a8538ba687.  | 
|--------|--------|

### Summary:
This PR cleans up debug code, improves output for prerelease packaging, and moves the `yarn publish` command out of the `else` block in `.github/workflows/npm-publish.yml`.

**Key points**:
- Cleaned up debug code in `.github/workflows/npm-publish.yml`.
- Improved output for prerelease packaging.
- Moved `yarn publish` command out of the `else` block.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)
<!--
ELLIPSIS_HIDDEN
-->
