### PR TITLE
fix: Memory type query search string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "show-config": "tsc --showConfig",
   "name": "@getzep/zep-js",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "Zep: Fast, scalable building blocks for production LLM apps",
   "private": false,
   "publishConfig": {

--- a/src/memory_manager.ts
+++ b/src/memory_manager.ts
@@ -216,7 +216,8 @@ export default class MemoryManager {
       const url = this.client.getFullUrl(`/sessions/${sessionID}/memory`);
       let params = lastn !== undefined ? `?lastn=${lastn}` : "";
       if (type) {
-         params += lastn !== undefined ? `&type=${type}` : `?type=${type}`;
+         params +=
+            lastn !== undefined ? `&memoryType=${type}` : `?memoryType=${type}`;
       }
       const response: Response = await handleRequest(
          fetch(`${url}${params}`, {


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 67c40e65d4871a202b8eb7c998c2644c2de28718.  | 
|--------|--------|

### Summary:
This PR modifies the `getMemory` function in the `MemoryManager` class to use `memoryType` instead of `type` as the query parameter for memory type.

**Key points**:
- Updated the `getMemory` function in the `MemoryManager` class.
- Changed the query parameter for memory type from `type` to `memoryType`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
