### PR TITLE
fix: ts-ignore langchain core and langchain errors

### DIFF
--- a/examples/langchain/message_history_vector_store_example.ts
+++ b/examples/langchain/message_history_vector_store_example.ts
@@ -30,6 +30,7 @@ async function combineDocuments(
 ) {
    const docStrings: string[] = await Promise.all(
       docs.map((doc) => {
+         // @ts-ignore
          return formatDocument(doc, documentPrompt);
       }),
    );
@@ -79,6 +80,7 @@ async function main() {
 
    const ragChain = setupAndRetrieval
       .pipe(prompt)
+      // @ts-ignore
       .pipe(model)
       .pipe(outputParser);
 

--- a/examples/langchain/vector_store_example.ts
+++ b/examples/langchain/vector_store_example.ts
@@ -25,6 +25,7 @@ async function combineDocuments(
 ) {
    const docStrings: string[] = await Promise.all(
       docs.map((doc) => {
+         // @ts-ignore
          return formatDocument(doc, documentPrompt);
       }),
    );
@@ -65,6 +66,7 @@ async function main() {
 
    const chain = setupAndRetrieval
       .pipe(prompt)
+      // @ts-ignore
       .pipe(model)
       .pipe(outputParser)
       .withConfig({

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,7 +647,24 @@
     uuid "^9.0.0"
     zod "^3.22.3"
 
-"@langchain/core@^0.1.23", "@langchain/core@~0.1.13", "@langchain/core@~0.1.29":
+"@langchain/core@^0.1.19", "@langchain/core@~0.1.13", "@langchain/core@~0.1.29":
+  version "0.1.40"
+  resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.1.40.tgz#bf947560aaac3b614b56cc9aefc1a3e0b6700f56"
+  integrity sha512-TNX7swnPNFNXftsFMuXLkPhk+9/tE2veLFzuiiuIi0Mz/+jgPi4klHx9jxS8+DHPgMvKzmwsoE8U879iPByXjw==
+  dependencies:
+    ansi-styles "^5.0.0"
+    camelcase "6"
+    decamelize "1.2.0"
+    js-tiktoken "^1.0.8"
+    langsmith "~0.1.7"
+    ml-distance "^4.0.0"
+    p-queue "^6.6.2"
+    p-retry "4"
+    uuid "^9.0.0"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.22.3"
+
+"@langchain/core@^0.1.23":
   version "0.1.29"
   resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.1.29.tgz#4337a9db35ee0281af3d50d6fbb9c84c5dd6be77"
   integrity sha512-MVrrb2J1Y08Yy6JnRDy/C/yxZj2PvO6wNkMs8657Q345SHs8iCbRX7Dy7rC69isUrpMjR7PvADFxV9rGvdoMBg==
@@ -3130,6 +3147,17 @@ langsmith@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.1.2.tgz#84889c4c5e6740917f881ae147404ca844fc4291"
   integrity sha512-dgz72jpbwOvwBRlWV1DvNVKhvfqOVC4YpegJprbitb10jBcFEhBkgaOaP2ThSe/c8lKq0Cb5sojQXn3wge25kA==
+  dependencies:
+    "@types/uuid" "^9.0.1"
+    commander "^10.0.1"
+    p-queue "^6.6.2"
+    p-retry "4"
+    uuid "^9.0.0"
+
+langsmith@~0.1.7:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.1.8.tgz#a98c7c3d0ecbf6c44be4b30f3be66070c099b963"
+  integrity sha512-GMEPhUPmkOPUih2ho07kSMhHYpCDkavc6Zg0XgBjhLsYqYaobOxFFNyOc806jOvH2yw2tmiKLuiAdlQAVbDnHg==
   dependencies:
     "@types/uuid" "^9.0.1"
     commander "^10.0.1"


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




> :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit e1d554ba5a146e0eb899998fee5d44306ae4a9c9.

### Summary:
This PR suppresses TypeScript compiler warnings by adding `ts-ignore` comments in two files: `message_history_vector_store_example.ts` and `vector_store_example.ts`.

**Key points**:
- Added `ts-ignore` comments in `message_history_vector_store_example.ts` and `vector_store_example.ts`.
- The comments are added before the `formatDocument` function call in the `combineDocuments` function and before the `model` pipe in the `main` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
