### PR TITLE
chore: Default to perpetual memory in get memory

### DIFF
--- a/src/memory_manager.ts
+++ b/src/memory_manager.ts
@@ -217,10 +217,14 @@ export default class MemoryManager {
    ): Promise<Memory | null> {
       const url = this.client.getFullUrl(`/sessions/${sessionID}/memory`);
       let params = lastn !== undefined ? `?lastn=${lastn}` : "";
-      if (type) {
-         params +=
-            lastn !== undefined ? `&memoryType=${type}` : `?memoryType=${type}`;
-      }
+
+      const memoryType = type ?? "perpetual";
+
+      params +=
+         lastn !== undefined
+            ? `&memoryType=${memoryType}`
+            : `?memoryType=${memoryType}`;
+
       const response: Response = await handleRequest(
          fetch(`${url}${params}`, {
             headers: this.client.headers,


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




> :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5178934403307dc73a0d90affe11c4ef8f88a659.

### Summary:
The pull request updates the `getMemory` function in the `MemoryManager` class to default the `memoryType` parameter to 'perpetual' if not provided.

**Key points**:
- Modified `getMemory` function in `MemoryManager` class in `/src/memory_manager.ts`.
- Set default value for `memoryType` parameter to 'perpetual'.
- Updated `params` string to include `memoryType`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
