### PR TITLE
feat(message_models.ts): Add 'norole' to RoleType enum and update getZepMessageRoleType function

### DIFF
--- a/src/message_models.ts
+++ b/src/message_models.ts
@@ -1,6 +1,12 @@
 import { MessageType } from "@langchain/core/messages";
 
-export type RoleType = "user" | "assistant" | "system" | "function" | "tool";
+export type RoleType =
+   | "user"
+   | "assistant"
+   | "system"
+   | "function"
+   | "tool"
+   | "norole";
 
 /**
  * IMessage interface for providing input to create a Message instance.
@@ -77,6 +83,6 @@ export const getZepMessageRoleType = (role: MessageType): RoleType => {
       case "tool":
          return "tool";
       default:
-         return "system";
+         return "norole";
    }
 };


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




> :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1b51963d3f66aaa8404232970c9b6c58efa46437.

### Summary:
This PR introduces a new 'norole' type to the `RoleType` enum and updates the `getZepMessageRoleType` function to return 'norole' as the default case in `/src/message_models.ts`.

**Key points**:
- Added 'norole' to `RoleType` enum in `/src/message_models.ts`
- Updated `getZepMessageRoleType` function to return 'norole' as default


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
