### PR TITLE
Append api suffix to base url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 /dist
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 .DS_Store
 /dist
-.idea

--- a/examples/memory/memory_example.ts
+++ b/examples/memory/memory_example.ts
@@ -12,12 +12,12 @@ function sleep(ms: number) {
         currentDate = Date.now();
     } while (currentDate - date < ms);
 }
-const projectApiKey = process.env.ZEP_API_KEY;
+const apiKey = process.env.ZEP_API_KEY;
 const apiUrl = process.env.ZEP_API_URL;
 async function main() {
     const client = new ZepClient({
-        apiKey: projectApiKey,
-        environment: apiUrl,
+        apiKey: apiKey!,
+        baseUrl: apiUrl!,
     });
 
     // Create a user

--- a/examples/users/users.ts
+++ b/examples/users/users.ts
@@ -3,12 +3,12 @@ import { ZepClient } from "../../src";
 import { CreateUserRequest, UpdateUserRequest } from "../../src/api";
 
 async function main() {
-    const projectApiKey = process.env.ZEP_API_KEY;
+    const apiKey = process.env.ZEP_API_KEY;
     const apiUrl = process.env.ZEP_API_URL;
 
     const client = new ZepClient({
-        apiKey: projectApiKey,
-        environment: apiUrl,
+        apiKey: apiKey!,
+        baseUrl: apiUrl!,
     });
 
     // Create multiple users

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getzep/zep-js",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "private": false,
     "repository": "https://github.com/getzep/zep-js",
     "description": "Zep: Fast, scalable building blocks for production LLM apps",

--- a/src/api/resources/memory/client/requests/ApidataAddMemoryRequest.ts
+++ b/src/api/resources/memory/client/requests/ApidataAddMemoryRequest.ts
@@ -11,10 +11,10 @@ import * as Zep from "../../../../index";
  *     }
  */
 export interface ApidataAddMemoryRequest {
-    /** Additional instruction for generating the facts. */
+    /** Additional instruction for generating the facts. Zep Cloud Only, will be ignored on Community Edition. */
     factInstruction?: string;
     /** A list of message objects, where each message contains a role and content. */
     messages: Zep.Message[];
-    /** Additional instruction for generating the summary. */
+    /** Additional instruction for generating the summary. Zep Cloud Only, will be ignored on Community Edition. */
     summaryInstruction?: string;
 }

--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -1,7 +1,31 @@
 import { ZepClient as BaseClient } from "../Client";
 import { Memory } from "./memory";
+import * as core from "../core";
+const API_SUFFIX = "api/v2"
+
+interface ZepOptions {
+    /**
+     * The base URL for the API. Must be a valid url, such as "http://localhost:8000".
+     */
+    baseUrl: string;
+    /**
+     * The API secret defined in the Zep Config
+     */
+    apiKey: string;
+    fetcher?: core.FetchFunction;
+}
 
 export class ZepClient extends BaseClient {
+    _options: BaseClient.Options = {}
+    constructor(protected readonly _zepOptions: ZepOptions) {
+        const baseClientOptions = {
+            environment: `${_zepOptions.baseUrl}/${API_SUFFIX}`,
+            apiKey: _zepOptions.apiKey,
+            fetcher: _zepOptions.fetcher
+        }
+        super(baseClientOptions)
+        this._options = baseClientOptions
+    }
     public get memory(): Memory {
         return new Memory(this._options);
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `ZepClient` to use `baseUrl` with API suffix and adjust examples accordingly.
> 
>   - **Behavior**:
>     - Change `ZepClient` constructor in `index.ts` to use `baseUrl` with `api/v2` suffix instead of `environment`.
>     - Update `examples/memory/memory_example.ts` and `examples/users/users.ts` to use `baseUrl` instead of `environment`.
>   - **Documentation**:
>     - Update comments in `ApidataAddMemoryRequest.ts` to specify Zep Cloud-only instructions.
>   - **Misc**:
>     - Bump version in `package.json` from `2.0.0` to `2.0.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fzep-js&utm_source=github&utm_medium=referral)<sup> for 54548b9957723c451c0a3848a5addc6012728956. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->