### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "3.23.0",
     "private": false,
     "repository": "https://github.com/getzep/zep-js",
+    "license": "Apache-2.0",
     "description": "Zep: Fast, scalable building blocks for production LLM apps",
     "type": "commonjs",
     "main": "./dist/cjs/index.js",


### PR DESCRIPTION
## Summary
- add the Apache-2.0 license field to the npm package manifest
- align package metadata with the repository LICENSE file

## Verification
- npm pack --dry-run --ignore-scripts --json
- node package manifest assertion
- git diff --check