### PR TITLE
Prepare TypeScript SDK release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   compile:
@@ -8,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/npm-publish-cloud.yml
+++ b/.github/workflows/npm-publish-cloud.yml
@@ -6,7 +6,6 @@ on:
     types: [published]
 jobs:
   build:
-    if: github.event.release.target_commitish == 'main'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -21,7 +20,7 @@ jobs:
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/}
           PACKAGE_VERSION=$(cat package.json | jq -r '.version')
-          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
           # Expects the tag to be in the format v1.0.0
           if [ "$TAG_VERSION" != "v$PACKAGE_VERSION" ]; then
             echo "Tag version $TAG_VERSION does not match the package.json version $PACKAGE_VERSION"
@@ -31,10 +30,10 @@ jobs:
         run: |
           # grep will return a non-zero exit code if the version does not match the release pattern
           if echo "$PACKAGE_VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' > /dev/null; then
-            echo "is_next=false" >> $GITHUB_ENV
+            echo "is_next=false" >> "$GITHUB_ENV"
           else
             echo "Packaging a prerelease version $PACKAGE_VERSION"
-            echo "is_next=true" >> $GITHUB_ENV
+            echo "is_next=true" >> "$GITHUB_ENV"
           fi
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary

- run SDK validation on pull requests while retaining pushes to `main`
- let release jobs publish the checked-out release tag instead of filtering on `target_commitish`
- update CI actions to their supported Node runtimes and quote GitHub environment-file paths

## Motivation

The monorepo SDK release orchestrator must be able to wait for CI on Fern-generated pull requests and publish a release from the exact merged commit. GitHub release `target_commitish` is metadata and is not a reliable release-integrity gate; the workflow already checks out the release tag and verifies that its version matches `package.json`.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/npm-publish-cloud.yml`
- `git diff --check`

## Impact

No SDK runtime code changes. This prepares the TypeScript repository for orchestrated SDK releases.
