### PR TITLE
Publish v4 to npm with pnpm, not yarn

### DIFF
--- a/.github/workflows/npm-publish-cloud.yml
+++ b/.github/workflows/npm-publish-cloud.yml
@@ -14,8 +14,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Setup yarn
-        run: npm install -g yarn
+      # The v4 generator pins pnpm in package.json and ships a pnpm lockfile.
+      # Corepack activates the pinned version; npm publish then runs prepack,
+      # which is "pnpm build", so pnpm has to be on PATH here too.
+      - name: Enable corepack
+        run: corepack enable
       - name: Compare package.json version with tag
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/}
@@ -36,7 +39,7 @@ jobs:
             echo "is_next=true" >> "$GITHUB_ENV"
           fi
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Publish package
         run: |
           publish() {


### PR DESCRIPTION
The publish workflow still installs with **yarn**. `ci.yml` moved to corepack + pnpm when the v4 generator switched package managers ([#210](https://github.com/getzep/zep-js/pull/210)), but `npm-publish-cloud.yml` was missed.

This is the workflow that runs during the **irreversible** half of a release — it fires on a published GitHub release, after the SDK merges and tags already exist.

Once a v4 generation lands, the branch has a pnpm manifest and `pnpm-lock.yaml` and no `yarn.lock`, so:

```
yarn install --frozen-lockfile
```

fails, and the package never reaches npm — with the tag and GitHub release already permanent and the version number never reusable. Python and Go would have published; npm would not.

Corepack activates the pinned pnpm. It is needed for the publish step too: `npm publish` runs `prepack`, which is `pnpm build`.

**Unchanged:** the prerelease branch still runs `publish --tag preview`, so `4.0.0-alpha.1` stays off npm's `latest` and `npm install @getzep/zep-cloud` keeps resolving v3. The release audit's two requirements on this file — `publish --tag` present, no `release.target_commitish` filter — both still hold.

Found while reviewing what Gate 2 approval would actually do on the live `4.0.0-alpha.1` run.