### PR TITLE
Publish v4 to npm on a Node that npm supports, and build first

### DIFF
--- a/.github/workflows/npm-publish-cloud.yml
+++ b/.github/workflows/npm-publish-cloud.yml
@@ -13,10 +13,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       # The v4 generator pins pnpm in package.json and ships a pnpm lockfile.
-      # Corepack activates the pinned version; npm publish then runs prepack,
-      # which is "pnpm build", so pnpm has to be on PATH here too.
+      # Corepack activates the pinned version.
       - name: Enable corepack
         run: corepack enable
       - name: Compare package.json version with tag
@@ -40,6 +39,13 @@ jobs:
           fi
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      # v3's package.json carried "prepack": "yarn build", so npm publish built
+      # the package on its way out. The v4 generator emits no prepack, and
+      # package.json ships only the "dist" directory -- so without an explicit
+      # build the tarball contains just LICENSE, README, reference.md and the
+      # manifest, and main points at a dist/ that is not in it.
+      - name: Build
+        run: pnpm build
       - name: Publish package
         run: |
           publish() {


### PR DESCRIPTION
The `4.0.0-alpha.1` publish failed with `ENEEDAUTH` — and would have published an **empty package** if it hadn't.

## Auth: the trust config is fine, the runtime wasn't

Trusted publishing is configured for `getzep/zep-js` → `npm-publish-cloud.yml`, and the job already requests `id-token: write`. The exchange never happened because npm refused to run:

```
npm warn cli npm v12.0.2 does not support Node.js v20.20.2.
This version of npm supports the following node versions:
`^22.22.2 || ^24.15.0 || >=26.0.0`
...
npm error code ENEEDAUTH
```

`npx -y npm@latest` now resolves npm 12; the job pinned Node 20. Node 24 lets OIDC run.

## The tarball is the more serious half

```
npm notice 11.4kB LICENSE
npm notice 13.5kB README.md
npm notice 10.7kB package.json
npm notice 61.0kB reference.md
npm notice total files: 4
```

**No `dist/`.** v3's `package.json` carried `"prepack": "yarn build"`, so `npm publish` built on its way out. The v4 generator emits **no prepack**, and `files` ships only `dist` — so `main: ./dist/cjs/index.js` pointed at something not in the tarball.

The auth failure is the only reason a broken package didn't reach npm under a version number that can never be reused. This builds explicitly instead of depending on a lifecycle script the generator no longer writes.

## Unchanged

The prerelease branch still runs `publish --tag preview`. The release audit's two requirements on this file both still hold.

## Follow-up for v3

`main`'s workflow has the same `node-version: '20'` + `npx -y npm@latest` pairing. It published 3.28.0 only because npm@latest still supported Node 20 then — **the next v3 release will fail identically.** Worth fixing there too, and pinning npm rather than tracking `@latest`.