### PR TITLE
Publish on a Node that npm supports

### DIFF
--- a/.github/workflows/npm-publish-cloud.yml
+++ b/.github/workflows/npm-publish-cloud.yml
@@ -13,7 +13,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # npx -y npm@latest resolves npm 12, which requires
+          # ^22.22.2 || ^24.15.0 || >=26. On Node 20 npm refuses to run, the
+          # trusted-publishing OIDC exchange never happens, and publish fails
+          # with ENEEDAUTH. This published 3.28.0 only because npm@latest still
+          # supported Node 20 at the time.
+          node-version: '24'
       - name: Setup yarn
         run: npm install -g yarn
       - name: Compare package.json version with tag


### PR DESCRIPTION
`npx -y npm@latest` now resolves **npm 12**, which requires Node `^22.22.2 || ^24.15.0 || >=26`. This job pins **Node 20**, so npm refuses to run, the trusted-publishing OIDC exchange never happens, and publish fails:

```
npm warn cli npm v12.0.2 does not support Node.js v20.20.2.
This version of npm supports the following node versions:
`^22.22.2 || ^24.15.0 || >=26.0.0`
...
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

**Nothing in this repo changed.** 3.28.0 published fine because npm@latest still supported Node 20 then. npm moved, and the next v3 release would fail this way. We hit it for real on the `v4` branch while publishing `4.0.0-alpha.1` — same workflow, same pairing — which is how it surfaced.

## Scope

Only the Node version moves. This branch's `package.json` still carries `"prepack": "yarn build"`, so `npm publish` keeps building on its way out, and the yarn install path is untouched. (The v4 branch additionally needed an explicit build step, because the v4 generator emits no `prepack` — not applicable here.)

## Worth considering separately

`npx -y npm@latest` tracks whatever npm ships. Pinning a known-good npm would stop a future npm major breaking publishing again, but that's a deliberate choice rather than part of this fix.