### PR TITLE
Declare an ontology with field builders

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,12 +2,25 @@
 #
 # v4 starts from Fern's generated SDK rather than v3's hand-written layer. Only
 # what must not be regenerated stays here:
-#   .github  — the SDK Release audit fails closed unless CI is protected
-#   LICENSE  — legal text, not a generated artifact
+#   .github                — the SDK Release audit fails closed unless CI is
+#                            protected
+#   LICENSE                — legal text, not a generated artifact
+#   src/ontology.ts        — hand-written: declares an ontology with field
+#                            builders, which the generated types cannot express
+#   tests/ontology.test.ts — its tests, which CI runs on the generated branch,
+#                            so a regeneration that breaks the DSL fails its
+#                            own PR
+#   src/exports.ts         — one generated line plus the ontology export, which
+#                            is what puts the DSL on the package root. Watch it
+#                            when the generator version moves: a new core
+#                            export would land here and be skipped.
 #
 # Anything ported forward from v3 is re-added deliberately, file by file.
 .github
 LICENSE
 .gitattributes
+src/ontology.ts
+tests/ontology.test.ts
+src/exports.ts
 .fern/replay.lock
 .fern/replay.yml

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,1 +1,2 @@
 export * from "./core/exports.js";
+export * from "./ontology.js";

--- a/src/ontology.ts
+++ b/src/ontology.ts
@@ -1,0 +1,211 @@
+/**
+ * Declare a Zep ontology with field builders.
+ *
+ * `graph.setOntology` and `project.setOntology` take an `Ontology` holding
+ * `EntityType` and `EdgeType` objects. Building those by hand means repeating
+ * every property's name, type and description as data. This module lets an
+ * ontology be declared once and derives the payload from it:
+ *
+ * ```ts
+ * import { buildOntology, entityFields } from "@getzep/zep-cloud";
+ *
+ * const Traveler = {
+ *     description: "Someone who takes trips.",
+ *     fields: {
+ *         homeCity: entityFields.text("The city they live in", { identity: true }),
+ *         trips: entityFields.integer("How many trips they have taken"),
+ *     },
+ * } as const;
+ *
+ * const TraveledTo = {
+ *     description: "A traveler visiting a destination.",
+ *     fields: { purpose: entityFields.text("Why they went") },
+ *     sourceTargets: [{ sourceEntityType: "Traveler", targetEntityType: "Destination" }],
+ * } as const;
+ *
+ * const ontology = buildOntology({
+ *     entities: { Traveler },
+ *     edges: { TRAVELED_TO: TraveledTo },
+ * });
+ * await client.graph.setOntology(graphUuid, ontology);
+ * ```
+ *
+ * The same object goes to `project.setOntology` for the project default. v3
+ * addressed many graphs in one call; v4 has one ontology endpoint per scope, so
+ * a caller targeting several graphs sends the same payload once per graph.
+ *
+ * These are plain functions rather than client methods on purpose: the generated
+ * clients already define `setOntology`, so extending them collides.
+ */
+
+import type * as Zep from "./api/index.js";
+import { EntityPropertyType } from "./api/index.js";
+
+/**
+ * One property of an entity or edge type.
+ *
+ * `value` is never populated. It carries the property's TypeScript type so that
+ * {@link EntityData} can read it back off a declaration, which is how data
+ * extracted for a type gets a type of its own.
+ */
+export interface PropertyDefinition<Value = unknown> {
+    readonly type: Zep.EntityPropertyType;
+    readonly description: string;
+    /**
+     * Whether the property is one of those that tell two nodes of the same type
+     * apart. Identity properties are sent in the type's `identityProperties`.
+     */
+    readonly identity?: boolean;
+    readonly value?: Value;
+}
+
+/** Options accepted by every field builder. */
+export interface FieldOptions {
+    readonly identity?: boolean;
+}
+
+/**
+ * The four property types the API accepts. Declared once: a change to the wire
+ * spelling is a change in the generated `EntityPropertyType` and nowhere here.
+ */
+export const entityFields = {
+    text: (description: string, options?: FieldOptions): PropertyDefinition<string> => ({
+        type: EntityPropertyType.Text,
+        description,
+        identity: options?.identity,
+    }),
+    integer: (description: string, options?: FieldOptions): PropertyDefinition<number> => ({
+        type: EntityPropertyType.Int,
+        description,
+        identity: options?.identity,
+    }),
+    float: (description: string, options?: FieldOptions): PropertyDefinition<number> => ({
+        type: EntityPropertyType.Float,
+        description,
+        identity: options?.identity,
+    }),
+    boolean: (description: string, options?: FieldOptions): PropertyDefinition<boolean> => ({
+        type: EntityPropertyType.Boolean,
+        description,
+        identity: options?.identity,
+    }),
+};
+
+/** An entity type declaration: a description the extraction model reads, and its properties. */
+export interface EntityDefinition {
+    readonly description: string;
+    readonly fields: Readonly<Record<string, PropertyDefinition>>;
+}
+
+/** An edge type declaration, which may also limit the entity type pairs it connects. */
+export interface EdgeDefinition extends EntityDefinition {
+    readonly sourceTargets?: readonly Zep.EdgeSourceTarget[];
+}
+
+/**
+ * The shape of the data extracted for a declared type, so a property bag read
+ * back off a node or edge can be typed by the declaration that produced it.
+ */
+export type EntityData<Definition extends EntityDefinition> = {
+    [Property in keyof Definition["fields"]]?: Definition["fields"][Property] extends PropertyDefinition<infer Value>
+        ? Value
+        : never;
+};
+
+export interface BuildOntologyInput {
+    /** Entity types by name. The API expects PascalCase names. */
+    readonly entities?: Readonly<Record<string, EntityDefinition>>;
+    /** Edge types by name. The API expects SCREAMING_SNAKE_CASE names. */
+    readonly edges?: Readonly<Record<string, EdgeDefinition>>;
+}
+
+/**
+ * Derive an `Ontology` from the given declarations.
+ *
+ * Pass the result to `graph.setOntology` for one graph, or to
+ * `project.setOntology` for the project default.
+ *
+ * A missing description throws rather than being sent empty: the extraction
+ * model reads descriptions to decide what belongs to a type, and the write path
+ * does not reject an empty one.
+ */
+export function buildOntology(input: BuildOntologyInput): Zep.Ontology {
+    const entityTypes: Zep.EntityType[] = [];
+    for (const [name, definition] of Object.entries(input.entities ?? {})) {
+        const { properties, identityProperties } = readFields(name, definition);
+        entityTypes.push({
+            name,
+            description: readDescription(name, definition),
+            properties,
+            ...(identityProperties.length > 0 ? { identityProperties } : {}),
+        });
+    }
+
+    const edgeTypes: Zep.EdgeType[] = [];
+    for (const [name, definition] of Object.entries(input.edges ?? {})) {
+        const { properties } = readFields(name, definition);
+        edgeTypes.push({
+            name,
+            description: readDescription(name, definition),
+            properties,
+            ...(definition.sourceTargets ? { sourceTargets: [...definition.sourceTargets] } : {}),
+        });
+    }
+
+    return { entityTypes, edgeTypes };
+}
+
+function readDescription(name: string, definition: EntityDefinition): string {
+    const description = definition.description?.trim();
+    if (!description) {
+        throw new Error(
+            `${name}: a type needs a description; the extraction model reads it to decide what belongs to this type`,
+        );
+    }
+    return description;
+}
+
+function readFields(
+    name: string,
+    definition: EntityDefinition,
+): { properties: Zep.EntityProperty[]; identityProperties: string[] } {
+    const properties: Zep.EntityProperty[] = [];
+    const identityProperties: string[] = [];
+
+    for (const [property, field] of Object.entries(definition.fields ?? {})) {
+        const description = field.description?.trim();
+        if (!description) {
+            throw new Error(`${name}.${property}: a property needs a description`);
+        }
+        properties.push({ name: property, description, type: field.type });
+        if (field.identity) {
+            identityProperties.push(property);
+        }
+    }
+
+    return { properties, identityProperties };
+}
+
+/**
+ * {@link EntityData} is checked here rather than in a test file: the test files
+ * are transpiled without type checking, so an assertion in one would hold
+ * whatever the type became. This block is type-only and compiles away.
+ */
+type Equals<Left, Right> = (<T>() => T extends Left ? 1 : 2) extends <T>() => T extends Right ? 1 : 2 ? true : false;
+type Assert<Check extends true> = Check;
+
+type ExampleDeclaration = {
+    readonly description: string;
+    readonly fields: {
+        readonly homeCity: PropertyDefinition<string>;
+        readonly trips: PropertyDefinition<number>;
+        readonly frequent: PropertyDefinition<boolean>;
+    };
+};
+
+type _EntityDataCarriesEachPropertyType = Assert<
+    Equals<
+        EntityData<ExampleDeclaration>,
+        { readonly homeCity?: string; readonly trips?: number; readonly frequent?: boolean }
+    >
+>;

--- a/tests/ontology.test.ts
+++ b/tests/ontology.test.ts
@@ -1,0 +1,128 @@
+import { buildOntology, entityFields } from "../src/ontology";
+import { Ontology } from "../src/serialization/types/Ontology";
+
+const Traveler = {
+    description: "Someone who takes trips.",
+    fields: {
+        homeCity: entityFields.text("The city they live in", { identity: true }),
+        trips: entityFields.integer("How many trips they have taken"),
+        rating: entityFields.float("Their average trip rating"),
+        frequent: entityFields.boolean("Whether they travel often"),
+    },
+} as const;
+
+const TraveledTo = {
+    description: "A traveler visiting a destination.",
+    fields: { purpose: entityFields.text("Why they went") },
+    sourceTargets: [{ sourceEntityType: "Traveler", targetEntityType: "Destination" }],
+} as const;
+
+describe("buildOntology", () => {
+    it("produces the documented payload", () => {
+        expect(buildOntology({ entities: { Traveler }, edges: { TRAVELED_TO: TraveledTo } })).toEqual({
+            entityTypes: [
+                {
+                    name: "Traveler",
+                    description: "Someone who takes trips.",
+                    identityProperties: ["homeCity"],
+                    properties: [
+                        { name: "homeCity", description: "The city they live in", type: "text" },
+                        { name: "trips", description: "How many trips they have taken", type: "int" },
+                        { name: "rating", description: "Their average trip rating", type: "float" },
+                        { name: "frequent", description: "Whether they travel often", type: "boolean" },
+                    ],
+                },
+            ],
+            edgeTypes: [
+                {
+                    name: "TRAVELED_TO",
+                    description: "A traveler visiting a destination.",
+                    properties: [{ name: "purpose", description: "Why they went", type: "text" }],
+                    sourceTargets: [{ sourceEntityType: "Traveler", targetEntityType: "Destination" }],
+                },
+            ],
+        });
+    });
+
+    it("survives the serialization the client puts it through", () => {
+        // The DSL builds the camelCase type; what reaches the API is what the
+        // generated serializer makes of it, which is where a wrong key shows up.
+        const ontology = buildOntology({ entities: { Traveler }, edges: { TRAVELED_TO: TraveledTo } });
+
+        expect(Ontology.jsonOrThrow(ontology)).toEqual({
+            entity_types: [
+                {
+                    name: "Traveler",
+                    description: "Someone who takes trips.",
+                    identity_properties: ["homeCity"],
+                    properties: [
+                        { name: "homeCity", description: "The city they live in", type: "text" },
+                        { name: "trips", description: "How many trips they have taken", type: "int" },
+                        { name: "rating", description: "Their average trip rating", type: "float" },
+                        { name: "frequent", description: "Whether they travel often", type: "boolean" },
+                    ],
+                },
+            ],
+            edge_types: [
+                {
+                    name: "TRAVELED_TO",
+                    description: "A traveler visiting a destination.",
+                    properties: [{ name: "purpose", description: "Why they went", type: "text" }],
+                    source_targets: [{ source_entity_type: "Traveler", target_entity_type: "Destination" }],
+                },
+            ],
+        });
+    });
+
+    it("omits identityProperties when no field is one", () => {
+        const Place = { description: "A place.", fields: { country: entityFields.text("Its country") } } as const;
+
+        expect(buildOntology({ entities: { Place } }).entityTypes?.[0]).not.toHaveProperty("identityProperties");
+    });
+
+    it("omits sourceTargets when the edge does not limit them", () => {
+        const Mentions = { description: "A mention.", fields: { note: entityFields.text("The note") } } as const;
+
+        expect(buildOntology({ edges: { MENTIONS: Mentions } }).edgeTypes?.[0]).not.toHaveProperty("sourceTargets");
+    });
+
+    it("lists identity properties in declaration order", () => {
+        const Place = {
+            description: "A place.",
+            fields: {
+                country: entityFields.text("Its country", { identity: true }),
+                region: entityFields.text("Its region"),
+                city: entityFields.text("Its city", { identity: true }),
+            },
+        } as const;
+
+        expect(buildOntology({ entities: { Place } }).entityTypes?.[0]?.identityProperties).toEqual([
+            "country",
+            "city",
+        ]);
+    });
+
+    it("builds an empty ontology from no declarations", () => {
+        // Sending an empty ontology is how a graph is handed back to the project
+        // default, so it has to build rather than throw.
+        expect(buildOntology({})).toEqual({ entityTypes: [], edgeTypes: [] });
+    });
+
+    it("rejects a type with no description, naming it", () => {
+        const Place = { description: "  ", fields: { country: entityFields.text("Its country") } } as const;
+
+        expect(() => buildOntology({ entities: { Place } })).toThrow(/^Place: a type needs a description/);
+    });
+
+    it("rejects a property with no description, naming it", () => {
+        const Place = { description: "A place.", fields: { country: entityFields.text("") } } as const;
+
+        expect(() => buildOntology({ entities: { Place } })).toThrow("Place.country: a property needs a description");
+    });
+
+    it("rejects an edge type with no description, naming it", () => {
+        const Mentions = { description: "", fields: { note: entityFields.text("The note") } } as const;
+
+        expect(() => buildOntology({ edges: { MENTIONS: Mentions } })).toThrow(/^MENTIONS: a type needs a description/);
+    });
+});


### PR DESCRIPTION
## What

`graph.setOntology` and `project.setOntology` take an `Ontology` of `EntityType` and `EdgeType` objects, so building one by hand means repeating every property's name, type and description as data. `buildOntology` derives that payload from declarations.

```ts
import { buildOntology, entityFields } from "@getzep/zep-cloud";

const Traveler = {
    description: "Someone who takes trips.",
    fields: {
        homeCity: entityFields.text("The city they live in", { identity: true }),
        trips: entityFields.integer("How many trips they have taken"),
    },
} as const;

const TraveledTo = {
    description: "A traveler visiting a destination.",
    fields: { purpose: entityFields.text("Why they went") },
    sourceTargets: [{ sourceEntityType: "Traveler", targetEntityType: "Destination" }],
} as const;

const ontology = buildOntology({
    entities: { Traveler },
    edges: { TRAVELED_TO: TraveledTo },
});
await client.graph.setOntology(graphUuid, ontology);
```

The same object goes to `project.setOntology` for the project default.

## Details

- **Identity properties.** A field built with `{ identity: true }` is listed in the type's `identityProperties`, which deduplication compares when two nodes of the same type are merge candidates. `EntityType` could carry it; nothing could express it.
- **`EntityData<typeof Declaration>`** reads the properties back as a TypeScript type, so data extracted for a declared type is typed by the declaration that produced it rather than as `unknown`.
- **Descriptions are required.** A type or property with an empty description throws, naming it, rather than sending an empty string. Descriptions are what decides what belongs to a type, so an empty one is a silent quality loss rather than a failure.
- **A plain function, not a client method.** The generated clients already define `setOntology`.

`entityFields.text` / `integer` / `float` / `boolean` keep v3's names and signature, so a v3 declaration ports by changing the wrapper. The types are the generated `EntityPropertyType` values rather than a second enum, and no `zod` schema is involved.

## Tests

9 tests in `tests/ontology.test.ts`, including the full built object and — separately — what the generated serializer makes of it, which is where a wrong key would actually show up (`identity_properties`, `source_targets`).

`EntityData`'s type-level guarantee is asserted in `src/ontology.ts`, not in the test file. The test files are transpiled without type checking, so an `expectTypeOf` assertion there holds whatever the type became — I confirmed this by deliberately breaking one and watching `pnpm test` pass. The assertion in `src/ontology.ts` is checked by `pnpm build`, which does fail when the type regresses.

## `.fernignore`

`src/ontology.ts` and `tests/ontology.test.ts`, plus `src/exports.ts` — one generated line and the ontology export, which is what puts the DSL on the package root. That last one is worth watching when the generator version moves: a new core export would land there and be skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)