### PR TITLE
Fix the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,58 +40,17 @@ npm install @getzep/zep-cloud
 > [!NOTE]
 > Zep Cloud [overview](https://help.getzep.com/concepts) and [cloud sdk guide](https://help.getzep.com/sdks).
 
-### Community Installation
-```bash
-npm install @getzep/zep-js
-```
-> [!NOTE]
-> Zep Community Edition [quick start](https://help.getzep.com/ce/quickstart) and [sdk guide](https://help.getzep.com/ce/sdks).
-
-### Zep v0.x Compatible SDK
-You can install Zep v0.x compatible sdk by running:
-```bash
-npm install @getzep/zep-js@^0.10.0
-```
-> [!NOTE]
-> Zep v0.x [quick start](https://help.getzep.com/ce/legacy/deployment/quickstart) and [sdk guide](https://help.getzep.com/ce/legacy/sdk).
-
 ### How Zep works
 
 Zep persists and recalls chat histories, and automatically generates summaries and other artifacts from these chat histories. It also embeds messages and summaries, enabling you to search Zep for relevant context from past conversations. Zep does all of this asynchronously, ensuring these operations don't impact your user's chat experience. Data is persisted to database, allowing you to scale out when growth demands.
-
-Zep also provides a simple, easy to use abstraction for document vector search called Document Collections. This is designed to complement Zep's core context features, but is not designed to be a general purpose vector database.
 
 Zep allows you to be more intentional about constructing your prompt:
 1. automatically adding a few recent messages, with the number customized for your app;
 2. a summary of recent conversations prior to the messages above;
 3. and/or contextually relevant summaries or messages surfaced from the entire chat session.
-4. and/or relevant Business data from Zep Document Collections.
-
-Zep Cloud offers:
-- **Fact Extraction:** Automatically build fact tables from conversations, without having to define a data schema upfront.
-- **Dialog Classification:** Instantly and accurately classify chat dialog. Understand user intent and emotion, segment users, and more. Route chains based on semantic context, and trigger events.
-- **Structured Data Extraction:** Quickly extract business data from chat conversations using a schema you define. Understand what your Assistant should ask for next in order to complete its task.
 
 You will also need to provide a Zep Project API key to your zep client.
 You can find out about zep projects in our [cloud docs](https://help.getzep.com/projects.html)
-
-### Using langchain zep classes with `zep-cloud`:
-`zep-cloud` sdk comes with `ZepChatMessageHistory`, `ZepVectorStore` and `ZepMemory`
-classes that are compatible with [`Langchain's JS expression language`](https://js.langchain.com/docs/expression_language/)
-
-In order to use these classes in your application, you need to make sure that you have
-`langchain` package installed:
-
-```bash
-npm install langchain@^0.1.23
-```
-
-You can import these classes in the following way:
-
-```typescript
-import { ZepChatMessageHistory, ZepVectorStore, ZepMemory } from "@getzep/zep-cloud/langchain"
-```
-
 
 ## Installation
 


### PR DESCRIPTION
## Rationale

The README describes capabilities this package does not ship, so a reader following it reaches for imports that do not exist and installs a different package.

## Changes

- Remove the langchain section (`ZepChatMessageHistory`, `ZepVectorStore`, `ZepMemory`): no `langchain` reference exists in `src` or in the dependencies.
- Remove document collections, and the fact-extraction / dialog-classification / structured-data-extraction bullets: none map to a client method or resource under `src/api/resources`.
- Remove the community and v0.x install sections, which install `@getzep/zep-js`. This repository publishes `@getzep/zep-cloud`.
- The generated half from `## Reference` onward is untouched.

## Impact and risks

None material. Documentation only; no source or published surface changes.

### Invariants

None.

### Required configs

None.
