### PR TITLE
Follow the edge endpoint rename in the ontology DSL

### DIFF
--- a/src/ontology.ts
+++ b/src/ontology.ts
@@ -20,7 +20,7 @@
  * const TraveledTo = {
  *     description: "A traveler visiting a destination.",
  *     fields: { purpose: entityFields.text("Why they went") },
- *     sourceTargets: [{ sourceEntityType: "Traveler", targetEntityType: "Destination" }],
+ *     sourceTargets: [{ source: "Traveler", target: "Destination" }],
  * } as const;
  *
  * const ontology = buildOntology({

--- a/tests/ontology.test.ts
+++ b/tests/ontology.test.ts
@@ -14,7 +14,7 @@ const Traveler = {
 const TraveledTo = {
     description: "A traveler visiting a destination.",
     fields: { purpose: entityFields.text("Why they went") },
-    sourceTargets: [{ sourceEntityType: "Traveler", targetEntityType: "Destination" }],
+    sourceTargets: [{ source: "Traveler", target: "Destination" }],
 } as const;
 
 describe("buildOntology", () => {
@@ -38,7 +38,7 @@ describe("buildOntology", () => {
                     name: "TRAVELED_TO",
                     description: "A traveler visiting a destination.",
                     properties: [{ name: "purpose", description: "Why they went", type: "text" }],
-                    sourceTargets: [{ sourceEntityType: "Traveler", targetEntityType: "Destination" }],
+                    sourceTargets: [{ source: "Traveler", target: "Destination" }],
                 },
             ],
         });
@@ -68,7 +68,7 @@ describe("buildOntology", () => {
                     name: "TRAVELED_TO",
                     description: "A traveler visiting a destination.",
                     properties: [{ name: "purpose", description: "Why they went", type: "text" }],
-                    source_targets: [{ source_entity_type: "Traveler", target_entity_type: "Destination" }],
+                    source_targets: [{ source: "Traveler", target: "Destination" }],
                 },
             ],
         });


### PR DESCRIPTION
## Rationale

The v4 contract publishes an edge type's endpoints as `source` and `target` — what v3's public API shipped, and what the spec has always specified. v4 had been publishing the internal persisted names. The ontology DSL and its tests are held out of regeneration by `.fernignore`, so they kept the old names while the generated types moved.

## Changes

- The DSL, its doc comment and its tests use `source` / `target`.

## Impact and risks

- **This must land before the next v4 SDK release.** The `4.0.0-alpha.5` train was cancelled at the production gate because of it — nothing published.
- The frozen files and the generated types disagree until this merges, so a regeneration between now and then leaves the package broken.

### Invariants

None.

### Required configs

None.
