### PR TITLE
Generate selective mutation idempotency keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
         "test:wire": "vitest --project wire"
     },
     "dependencies": {
+        "uuid": "^10.0.0",
         "zod": "^3.23.8"
     },
     "devDependencies": {
@@ -242,7 +243,6 @@
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10",
-        "uuid": "^10.0.0",
         "@types/uuid": "^10.0.0",
         "@faker-js/faker": "^8.4.1"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      uuid:
+        specifier: ^10.0.0
+        version: 10.0.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -33,9 +36,6 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
-      uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
       vitest:
         specifier: ^4.1.1
         version: 4.1.11(@types/node@20.19.43)(msw@2.11.2(@types/node@20.19.43)(typescript@5.9.3))(vite@8.2.2(@types/node@20.19.43)(terser@5.51.0))

--- a/src/core/headers.ts
+++ b/src/core/headers.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 export function mergeHeaders(...headersArray: (Record<string, unknown> | null | undefined)[]): Record<string, unknown> {
     const result: Record<string, unknown> = {};
 
@@ -24,7 +26,9 @@ export function mergeOnlyDefinedHeaders(
         .filter((headers) => headers != null)
         .flatMap((headers) => Object.entries(headers))) {
         const insensitiveKey = key.toLowerCase();
-        if (value != null) {
+        if (insensitiveKey === "idempotency-key" && value == null) {
+            result[insensitiveKey] = uuidv4();
+        } else if (value != null) {
             result[insensitiveKey] = value;
         }
     }

--- a/tests/fixtures/generatedIdempotencyClient.ts
+++ b/tests/fixtures/generatedIdempotencyClient.ts
@@ -1,0 +1,31 @@
+import { requestWithRetries } from "../../src/core/fetcher/requestWithRetries";
+import { mergeHeaders, mergeOnlyDefinedHeaders } from "../../src/core/headers";
+
+type RequestOptions = {
+    idempotencyKey?: string;
+    headers?: Record<string, unknown>;
+};
+
+type Request = (headers: Record<string, unknown>) => Promise<Response>;
+
+export class GeneratedIdempotencyClientFixture {
+    public mutationHeaders(requestOptions?: RequestOptions): Record<string, unknown> {
+        return mergeHeaders(
+            mergeOnlyDefinedHeaders({ "Idempotency-Key": requestOptions?.idempotencyKey }),
+            requestOptions?.headers,
+        );
+    }
+
+    public getReadHeaders(): Record<string, unknown> {
+        return mergeHeaders();
+    }
+
+    public postReadHeaders(): Record<string, unknown> {
+        return mergeHeaders();
+    }
+
+    public async mutate(request: Request, requestOptions?: RequestOptions): Promise<Response> {
+        const headers = this.mutationHeaders(requestOptions);
+        return requestWithRetries(() => request(headers), 1);
+    }
+}

--- a/tests/unit/headers.test.ts
+++ b/tests/unit/headers.test.ts
@@ -1,0 +1,51 @@
+import { GeneratedIdempotencyClientFixture } from "../fixtures/generatedIdempotencyClient";
+
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("generated idempotency headers", () => {
+    const client = new GeneratedIdempotencyClientFixture();
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("generates a UUIDv4 for a marked mutation", () => {
+        expect(client.mutationHeaders()["idempotency-key"]).toMatch(UUID_V4_PATTERN);
+    });
+
+    it("reuses the generated key across retries", async () => {
+        vi.useFakeTimers();
+        const keys: unknown[] = [];
+        const request = vi
+            .fn<(headers: Record<string, unknown>) => Promise<Response>>()
+            .mockImplementationOnce(async (headers) => {
+                keys.push(headers["idempotency-key"]);
+                return new Response(null, { status: 500 });
+            })
+            .mockImplementationOnce(async (headers) => {
+                keys.push(headers["idempotency-key"]);
+                return new Response(null, { status: 200 });
+            });
+
+        const responsePromise = client.mutate(request);
+        await vi.runAllTimersAsync();
+        const response = await responsePromise;
+
+        expect(response.status).toBe(200);
+        expect(request).toHaveBeenCalledTimes(2);
+        expect(keys[0]).toMatch(UUID_V4_PATTERN);
+        expect(keys[1]).toBe(keys[0]);
+    });
+
+    it("preserves a caller-provided key", () => {
+        expect(client.mutationHeaders({ idempotencyKey: "caller-key" })["idempotency-key"]).toBe("caller-key");
+    });
+
+    it("omits the header from an unmarked GET read", () => {
+        expect(client.getReadHeaders()).not.toHaveProperty("idempotency-key");
+    });
+
+    it("omits the header from an unmarked POST read", () => {
+        expect(client.postReadHeaders()).not.toHaveProperty("idempotency-key");
+    });
+});


### PR DESCRIPTION
## Rationale
Generate an idempotency key when an endpoint explicitly declares the mutation header placeholder.

## Changes
- Generate a UUIDv4 for a missing mutation key and retain it across retries.
- Preserve caller-supplied keys.
- Add focused core and retry tests.

## Impact and risks
Draft: do not merge until regeneration removes mutation placeholders from read-only POST methods and the combined generated-client tests pass.

### Invariants
None

### Required configs
None